### PR TITLE
fix: remove deprecated /review command from docs

### DIFF
--- a/part1/02-quickstart.md
+++ b/part1/02-quickstart.md
@@ -82,7 +82,6 @@ cat error.log | claude "找出错误原因"
 | `/config` | 查看或修改配置 |
 | `/model` | 切换模型 |
 | `/commit` | 生成 git commit 信息并提交 |
-| `/review` | 代码审查 |
 | `/exit` | 退出 |
 
 ---

--- a/part1/02-quickstart_en.md
+++ b/part1/02-quickstart_en.md
@@ -82,7 +82,6 @@ In interactive mode, slash commands are shortcuts to control Claude Code behavio
 | `/config` | View or modify configuration |
 | `/model` | Switch model |
 | `/commit` | Generate git commit message and commit |
-| `/review` | Code review |
 | `/exit` | Exit |
 
 ---

--- a/part7/20-skills.md
+++ b/part7/20-skills.md
@@ -91,7 +91,6 @@ Claude Code 有大量内置 Skills（`src/skills/bundled/`）：
 | Skill | 功能 |
 |-------|------|
 | `/commit` | 生成并执行 git commit |
-| `/review` | 代码审查 |
 | `/ship` | 完整的发布流程（测试→构建→发布） |
 | `/plan` | 生成实现计划 |
 | `/document-release` | 更新发布文档 |
@@ -154,8 +153,8 @@ Claude Code 支持动态发现 Skills（`discoveredSkillNames`）：
 private discoveredSkillNames = new Set<string>()
 
 // 当 Claude 在对话中提到某个 Skill 时，自动加载
-// 例如：用户说"用 /review 帮我审查代码"
-// Claude Code 会检查是否有 review Skill，如果有则加载
+// 例如：用户说"用 /plan 帮我制定实现计划"
+// Claude Code 会检查是否有 plan Skill，如果有则加载
 ```
 
 这让 Skills 可以在对话中被动态引用，而不需要提前知道所有可用的 Skills。
@@ -197,7 +196,7 @@ Skills 和斜杠命令（`/help`、`/clear` 等）的区别：
 | 执行方式 | 直接执行代码 | 作为提示发送给 Claude |
 | 可扩展性 | 需要修改源码 | 用户可以自定义 |
 | 能力范围 | 系统级操作 | AI 辅助工作流 |
-| 示例 | `/clear`、`/cost` | `/commit`、`/review` |
+| 示例 | `/clear`、`/cost` | `/commit`、`/plan` |
 
 ---
 

--- a/part7/20-skills_en.md
+++ b/part7/20-skills_en.md
@@ -91,7 +91,6 @@ Claude Code has many built-in Skills (`src/skills/bundled/`):
 | Skill | Function |
 |-------|------|
 | `/commit` | Generate and execute git commit |
-| `/review` | Code review |
 | `/ship` | Complete release process (test→build→release) |
 | `/plan` | Generate implementation plan |
 | `/document-release` | Update release documentation |
@@ -154,8 +153,8 @@ Claude Code supports dynamic Skills discovery (`discoveredSkillNames`):
 private discoveredSkillNames = new Set<string>()
 
 // When Claude mentions a Skill in conversation, automatically load it
-// Example: user says "use /review to help me review code"
-// Claude Code checks if review Skill exists, loads it if found
+// Example: user says "use /plan to help me create implementation plan"
+// Claude Code checks if plan Skill exists, loads it if found
 ```
 
 This allows Skills to be dynamically referenced in conversations without needing to know all available Skills in advance.
@@ -197,7 +196,7 @@ Differences between Skills and slash commands (`/help`, `/clear`, etc.):
 | Execution | Direct code execution | Sent as prompt to Claude |
 | Extensibility | Requires source code modification | User-customizable |
 | Capability scope | System-level operations | AI-assisted workflows |
-| Examples | `/clear`, `/cost` | `/commit`, `/review` |
+| Examples | `/clear`, `/cost` | `/commit`, `/plan` |
 
 ---
 


### PR DESCRIPTION
## Problem

The `/review` slash command has been deprecated in recent Claude Code versions, but the guide still lists it as a built-in command in multiple places. Users following the guide will try to use `/review` and get confused when it doesnt work.

## What I changed

Removed `/review` references from 4 files (both Chinese and English versions):

**part1/02-quickstart.md + _en.md:**
- Removed `/review` from the built-in commands table

**part7/20-skills.md + _en.md:**
- Removed `/review` from the built-in Skills table
- Updated the dynamic loading example from `/review` to `/plan` (which is still a valid skill)
- Updated the Commands vs Skills comparison table from `/review` to `/plan`

## Why /plan as replacement example

`/plan` is still an active built-in skill that demonstrates the same concept (AI-assisted workflow triggered by slash command). It's a good replacement for the example because planning is something every developer does.

Closes #5